### PR TITLE
Docker Support

### DIFF
--- a/lib/hookup/post_checkout.rb
+++ b/lib/hookup/post_checkout.rb
@@ -59,8 +59,8 @@ class Hookup
 
       update_submodules
       bundle
-      migrate
       yarn_install
+      migrate
     end
 
     def update_submodules
@@ -165,12 +165,21 @@ class Hookup
     end
 
     def yarn?
-      File.exist?('yarn.lock')
+      yarn_lock_files.any?
     end
 
     def yarn_install
       return unless yarn?
-      system 'yarn install'
+
+      yarn_lock_files.each do |lock_file|
+        Dir.chdir(File.dirname(lock_file)) do
+          system "yarn install"
+        end
+      end
+    end
+
+    def yarn_lock_files
+      @yarn_lock_files ||= Dir.glob("**/yarn.lock").reject { |path| path =~ /node_modules/ }
     end
 
     def skipped?


### PR DESCRIPTION
### Summary
Does a couple of things:
- Makes the `yarn` step more robust, finding nested `yarn.lock` files. This should allow us to drop root-level `package.json` files from our projects that only exists to auto-install changed npm dependencies when switching branches.
- Adds support for projects using Docker Compose. Because the Dockerfile should specify how to install dependencies, rebuilding should install any changes automatically and fall back to the cached results of each step if there are no changes. When running migrations, this script does assume that the rails container will be called "rails" in the `docker-compose.yml` file.